### PR TITLE
remove data source filtering and fix source type warning

### DIFF
--- a/src/Pages/Results.jsx
+++ b/src/Pages/Results.jsx
@@ -30,13 +30,11 @@ const Results = (props) => {
     CUSTOM: 'custom'
   };
 
-  const INITIAL_DATA_SOURCE = SEARCH_CRITERIA["data-option"];
-
   // State management
   const [data, setData] = useState([]);
   const [sourceType, setSourceType] = useState(SEARCH_CRITERIA["file-type"]);
   const [filters, setFilters] = useState({
-    dataSource: INITIAL_DATA_SOURCE,
+    dataSource: "all",
     dateRange: '7days',
     startDate: '',
     endDate: '',
@@ -90,13 +88,7 @@ const Results = (props) => {
             parsedData = [];
         }
 
-
-        let updatedParsedData = parsedData;
-        if (INITIAL_DATA_SOURCE !== 'all') {
-          updatedParsedData = parsedData.filter(item => item.type === INITIAL_DATA_SOURCE);
-        }
-
-        let slicedData = updatedParsedData.slice(0, MAX_TOTAL_ITEMS);
+        let slicedData = parsedData.slice(0, MAX_TOTAL_ITEMS);
 
         setData(slicedData);
         console.log("Setting data:", slicedData);

--- a/src/Pages/Search.jsx
+++ b/src/Pages/Search.jsx
@@ -434,7 +434,7 @@ function Search({ onSearchSubmit }) {
                           <span>Type:</span>
                           <span className="bg-[#2C2C2C] p-1 px-2 rounded-sm ml-4 cursor-pointer w-max">
                             <select
-                              name="structured[file-type]"
+                              name="crawler-type"
                               className="focus:outline-none"
                             >
                               <option value="recursive">Recursive</option>


### PR DESCRIPTION
I set the initial data source to "all" and removed the data source filtering that was based on the search criteria.

There were two select elements with the same name, overriding the data source file option and causing a warning in the console. I renamed the select element for the crawler type option.